### PR TITLE
add source maps so developers don't have to dig through compiled files

### DIFF
--- a/extension/webpack.config.js
+++ b/extension/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 
 module.exports = {
   entry: path.resolve(__dirname, './index.js'),
+  devtool: 'source-map',
   output: {
     filename: './extension/build/unsize.js'
   },


### PR DESCRIPTION
allows developers to do `cmd+O` -> `filename.js` and see the original ES6+ code rather than digging through a concatenated/transpiled bundle.js file.

requires going into Dev Tools -> Settings -> Enable JavaScript Source Maps to take advantage of this